### PR TITLE
OnStart called after audio finished playing and making 'touchDownAndUpGesture' work after 'moveGesture' has began

### DIFF
--- a/Example/iRecordView/ViewController.swift
+++ b/Example/iRecordView/ViewController.swift
@@ -59,7 +59,7 @@ class ViewController: UIViewController,RecordViewDelegate {
 
         recordView.trailingAnchor.constraint(equalTo: recordButton.leadingAnchor, constant: -20).isActive = true
         recordView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10).isActive = true
-        recordView.bottomAnchor.constraint(equalTo: recordButton.bottomAnchor).isActive = true
+        recordView.centerYAnchor.constraint(equalTo: recordButton.centerYAnchor).isActive = true
         recordButton.recordView = recordView
 
         recordView.delegate = self

--- a/Source/RecordButton.swift
+++ b/Source/RecordButton.swift
@@ -41,7 +41,7 @@ open class RecordButton: UIButton, UIGestureRecognizerDelegate {
         setTitle("", for: .normal)
 
         if image(for: .normal) == nil {
-            let image = UIImage.fromPod("mic_blue")
+            let image = UIImage.fromPod("mic_blue").withRenderingMode(.alwaysTemplate)
             setImage(image, for: .normal)
             
             tintColor = .blue

--- a/Source/RecordButton.swift
+++ b/Source/RecordButton.swift
@@ -54,7 +54,7 @@ open class RecordButton: UIButton, UIGestureRecognizerDelegate {
         
 
         touchDownAndUpGesture = iGesutreRecognizer(target: self, action: #selector(handleUpAndDown(_:)))
-        touchDownAndUpGesture.gestureDelegate = self
+        touchDownAndUpGesture.delegate = self
 
 
         addGestureRecognizer(moveGesture)
@@ -89,7 +89,6 @@ open class RecordButton: UIButton, UIGestureRecognizerDelegate {
         recordView.onTouchUp(recordButton: self)
     }
 
-
     @objc private func touchMoved(_ sender: UIPanGestureRecognizer) {
         recordView.touchMoved(recordButton: self, sender: sender)
     }
@@ -101,24 +100,23 @@ open class RecordButton: UIButton, UIGestureRecognizerDelegate {
 
         case .ended:
             recordView.onTouchUp(recordButton: self)
+            
+        case .cancelled:
+            recordView.onTouchCancelled(recordButton: self)
 
         default:
             break
         }
     }
+    
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return (gestureRecognizer == touchDownAndUpGesture && otherGestureRecognizer == moveGesture) || (gestureRecognizer == moveGesture && otherGestureRecognizer == touchDownAndUpGesture)
+    }
 
 
 }
 
-extension RecordButton: GesutreDelegate {
-    func onStart() {
-        recordView.onTouchDown(recordButton: self)
-    }
-
-    func onEnd() {
-        recordView.onTouchUp(recordButton: self)
-    }
-
+extension RecordButton {
     open override func layoutSubviews() {
         super.layoutSubviews()
         superview?.bringSubviewToFront(self)

--- a/Source/RecordView.swift
+++ b/Source/RecordView.swift
@@ -157,14 +157,14 @@ public class RecordView: UIView, CAAnimationDelegate {
     private func onStart(recordButton: RecordButton) {
         isSwiped = false
 
+        self.prepareToStartRecording(recordButton: recordButton)
+
         if isSoundEnabled {
             audioPlayer.playAudioFile(soundType: .start)
             audioPlayer.didFinishPlaying = { [weak self] _ in
-                self?.prepareToStartRecording(recordButton: recordButton)
                 self?.delegate?.onStart()
             }
         } else {
-            prepareToStartRecording(recordButton: recordButton)
             delegate?.onStart()
         }
     }

--- a/Source/RecordView.swift
+++ b/Source/RecordView.swift
@@ -24,6 +24,7 @@ public class RecordView: UIView, CAAnimationDelegate {
     public weak var delegate: RecordViewDelegate?
     public var offset: CGFloat = 20
     public var isSoundEnabled = true
+    public var buttonTransformScale: CGFloat = 2
 
     public var slideToCancelText: String! {
         didSet {
@@ -111,14 +112,14 @@ public class RecordView: UIView, CAAnimationDelegate {
         arrow.heightAnchor.constraint(equalToConstant: 15).isActive = true
 
         slideToCancelStackVIew.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
-        slideToCancelStackVIew.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
+        slideToCancelStackVIew.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
 
 
         timerStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
-        timerStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
+        timerStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
 
 
-        mTransform = CGAffineTransform(scaleX: 2.0, y: 2.0)
+        mTransform = CGAffineTransform(scaleX: buttonTransformScale, y: buttonTransformScale)
 
         audioPlayer = AudioPlayer()
     }

--- a/Source/iGesutreRecognizer.swift
+++ b/Source/iGesutreRecognizer.swift
@@ -8,22 +8,21 @@
 
 import UIKit
 
-protocol GesutreDelegate {
-    func onStart()
-    func onEnd()
-}
-
-
 class iGesutreRecognizer: UIGestureRecognizer {
-    var gestureDelegate: GesutreDelegate?
-
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
-        gestureDelegate?.onStart()
+        guard state != .began else {
+            return
+        }
+        state = .began
     }
 
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
-        gestureDelegate?.onEnd()
+        state = .ended
+    }
+    
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
+        state = .cancelled
     }
 
 }


### PR DESCRIPTION
- When 'onStart' is called and sound is enabled recorder records the 'record_start.wav'. solved it by using a closure which notifies when sound has finished playing
- Sometimes sounds does not get played. Solved it by , setting category of audio session and prepareToPlay
- Sometimes onTouchUp was not being called even when touch has ended. solved it by removing gestureDelegate from iGestureRecognizer and set the state property and added functionality handle when touch is cancelled